### PR TITLE
Make shadow run tests automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /node_modules/
 /resources/public/app-js
 /resources/public/portfolio-js
+resources/test/tests.js

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -9,4 +9,10 @@
   :portfolio
   {:target :browser
    :modules {:main {:init-fn tic-tac-toe.scenes/main}}
-   :dev {:output-dir "resources/public/portfolio-js"}}}}
+   :dev {:output-dir "resources/public/portfolio-js"}}
+
+  :test
+  {:target    :node-test
+   :output-to "resources/test/tests.js"
+   :ns-regexp "-test$"
+   :autorun   true}}}


### PR DESCRIPTION
Adding a node test target with `:autorun`.

Starting the watcher like so will have the tests running and reported by shadow whenever a file changes:

```
npx shadow-cljs -d cider/cider-nrepl:0.52.1 watch :app :portfolio :test)
```
